### PR TITLE
Add modern landing page and dashboard skeletons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,9 @@ import TemplateCreate from './components/templates/TemplateCreate';
 import TemplateDetails from './components/templates/TemplateDetails';
 import Login from './components/Auth/Login';
 import Register from './components/Auth/Register';
+import LandingPage from './components/LandingPage';
+import ClientPanel from './components/ClientPanel';
+import AdminPanel from './components/AdminPanel';
 import { auth } from './firebase';
 
 function App() {
@@ -25,6 +28,9 @@ function App() {
   return (
     <Router>
       <Routes>
+        <Route path='/' element={<LandingPage />} />
+        <Route path='/client' element={<ClientPanel />} />
+        <Route path='/admin' element={<AdminPanel />} />
         <Route path='/templates' element={<TemplatesList />} />
         <Route path='/templates/create' element={<TemplateCreate />} />
         <Route path='/templates/edit/:id' element={<TemplateCreate />} />
@@ -37,7 +43,7 @@ function App() {
           path='/register'
           element={user ? <Navigate to='/templates' /> : <Register />}
         />
-        <Route path='*' element={<Navigate to='/login' />} />
+        <Route path='*' element={<Navigate to='/' />} />
       </Routes>
     </Router>
   );

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function AdminPanel() {
+  return (
+    <div>
+      <h1>Admin Panel</h1>
+      <p>Manage the application here.</p>
+    </div>
+  );
+}
+
+export default AdminPanel;

--- a/src/components/ClientPanel.jsx
+++ b/src/components/ClientPanel.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function ClientPanel() {
+  return (
+    <div>
+      <h1>Client Panel</h1>
+      <p>Welcome to your dashboard.</p>
+    </div>
+  );
+}
+
+export default ClientPanel;

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -1,0 +1,46 @@
+.landing-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #4b6cb7 0%, #182848 100%);
+  color: #ffffff;
+}
+
+.landing-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.landing-header nav a {
+  margin-left: 1rem;
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.hero {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 2rem;
+}
+
+.hero h2 {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.cta {
+  margin-top: 1rem;
+  padding: 0.8rem 1.4rem;
+  background-color: #ffffff;
+  color: #182848;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: bold;
+}

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './LandingPage.css';
+
+function LandingPage() {
+  return (
+    <div className="landing-container">
+      <header className="landing-header">
+        <h1>AI DocParser</h1>
+        <nav>
+          <Link to="/login">Login</Link>
+          <Link to="/register">Sign Up</Link>
+        </nav>
+      </header>
+      <section className="hero">
+        <h2>Parse Documents with AI</h2>
+        <p>Automate your document workflow with our modern parser.</p>
+        <Link className="cta" to="/register">Get Started</Link>
+      </section>
+    </div>
+  );
+}
+
+export default LandingPage;


### PR DESCRIPTION
## Summary
- introduce new LandingPage with modern styles
- scaffold ClientPanel and AdminPanel components
- wire new routes for '/', '/client', '/admin'
- update navigation defaults

## Testing
- `npm run lint` *(fails: React lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68506d61021c8328b9de1dd6b15e6d60